### PR TITLE
Implement typeahead on club-form for external-id selection

### DIFF
--- a/src/app/core/services/api/v2/club.service.ts
+++ b/src/app/core/services/api/v2/club.service.ts
@@ -68,6 +68,13 @@ export class ClubService {
       return this.httpClient.get<PaginatedResponse<Club>>(this.clubsUrl, { params });
    }
 
+   getClubsAliases(search: string): Observable<string[]> {
+      const params = new HttpParams({ fromObject: { search: search } });
+      return this.httpClient
+         .get<{ aliases: string[] }>(`${this.clubsUrl}/aliases`, { params })
+         .pipe(map(response => response.aliases));
+   }
+
    public updateClub(clubId: number, club: Partial<Club>): Observable<Club> {
       const body = club.image ? serialize(club, { indices: true, nullsAsUndefineds: true }) : club;
       return this.httpClient.post<{ club: Club }>(`${this.clubsUrl}/${clubId}`, body).pipe(map(response => response.club));

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -19,7 +19,8 @@ export class SettingsService {
       ngSelect: {
          notFoundText: 'Нічого не знайдено',
          typeToSearchText: 'Почніть вводити текст для пошуку',
-         loadingText: 'Завантаження'
+         loadingText: 'Завантаження',
+         addTagText: 'Добавити власний варіант'
       }
    };
 }

--- a/src/app/manage/manage-club/manage-club.module.ts
+++ b/src/app/manage/manage-club/manage-club.module.ts
@@ -10,9 +10,10 @@ import { ManageClubRoutingModule } from './manage-club-routing.module';
 import { ManageClubComponent } from './manage-club.component';
 import { ClubFormComponent } from './shared/club-form/club-form.component';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgSelectModule } from '@ng-select/ng-select';
 
 @NgModule({
-   imports: [CommonModule, ReactiveFormsModule, ManageClubRoutingModule, SharedModule, NgbTooltipModule],
+   imports: [CommonModule, ReactiveFormsModule, ManageClubRoutingModule, SharedModule, NgbTooltipModule, NgSelectModule],
    declarations: [ManageClubComponent, ClubTableComponent, ClubCreateComponent, ClubEditComponent, ClubFormComponent]
 })
 export class ManageClubModule {}

--- a/src/app/manage/manage-club/shared/club-form/club-form.component.html
+++ b/src/app/manage/manage-club/shared/club-form/club-form.component.html
@@ -18,7 +18,20 @@
       <div class="col-12 col-md-6">
          <div class="form-group" [class.form-group-invalid]="showFormInvalidClass(clubForm.get('link'))">
             <label for="link" class="font-weight-bold">Назва англійською:</label>
-            <input type="text" id="link" formControlName="link" autocomplete="off" class="form-control" />
+            <ng-select
+               [items]="aliases$ | async"
+               formControlName="link"
+               [loading]="aliasesLoading"
+               [loadingText]="ngSelectTexts.loadingText"
+               [notFoundText]="ngSelectTexts.notFoundText"
+               [typeToSearchText]="ngSelectTexts.typeToSearchText"
+               [addTagText]="ngSelectTexts.addTagText"
+               [editableSearchTerm]="true"
+               [addTag]="true"
+               [minlength]="2"
+               [typeahead]="aliasesInput$"
+            >
+            </ng-select>
             <div [hidden]="!showFormErrorMessage(clubForm.get('link'), 'required')" class="error-message">
                <small>Назва англійською обов'язкова</small>
             </div>


### PR DESCRIPTION
For better [integration with result-service](https://github.com/andrewshostak/prognoz_api/pull/23)